### PR TITLE
Fix issues with multiple types for parameter and duplicate hooks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 const defaultConfig: WPHooksDocConfig = {
   input: '.',
   outputDir: './wp-hooks-docs',
-  ignoreFiles: [],
+  ignoreFiles: ['/tests/', '/vendor/', '/node_modules/'],
   ignoreHooks: [],
   title: 'Plugin Hooks Documentation',
   tagline: 'Documentation for the plugin hooks',

--- a/src/collectors/hook-collector.ts
+++ b/src/collectors/hook-collector.ts
@@ -82,7 +82,7 @@ export class HookCollector {
         // Merge multiple hooks with the same name
         const mergedHook = { ...hooks[0] };
 
-        // Use the first non-empty source
+        // Collect sources of all hooks.
         mergedHook.files = [];
         hooks.forEach((h) => {
           const file = {

--- a/src/collectors/hook-collector.ts
+++ b/src/collectors/hook-collector.ts
@@ -60,16 +60,50 @@ export class HookCollector {
   }
 
   private transformHooks(rawData: RawHookCollection): HookCollection {
-    // Deduplicate hooks based on name
+    // Helper function to merge hooks with the same name and transform them.
+    const prepareHooks = (hooks: RawHookData['hooks']): Hook[] => {
+      const hookMap = new Map<string, RawHookData['hooks'][0][]>();
+
+      // Group hooks by name
+      hooks.forEach((hook) => {
+        const hookId = this.getHookId(this.escapeHookName(hook.name));
+        if (!hookMap.has(hookId)) {
+          hookMap.set(hookId, []);
+        }
+        hookMap.get(hookId)?.push(hook);
+      });
+
+      // Merge and transform hooks
+      return Array.from(hookMap.entries()).map(([_, hooks]) => {
+        if (hooks.length === 1) {
+          return this.transformHook(hooks[0]);
+        }
+
+        // Merge multiple hooks with the same name
+        const mergedHook = { ...hooks[0] };
+
+        // Use the first non-empty source
+        mergedHook.files = [];
+        hooks.forEach((h) => {
+          const file = {
+            file: h.file || '',
+            line: h.line || 0,
+          };
+          mergedHook.files?.push(file);
+        });
+
+        return this.transformHook(mergedHook);
+      });
+    };
+
     return {
-      actions: rawData.actions.hooks.map(this.transformHook.bind(this)),
-      filters: rawData.filters.hooks.map(this.transformHook.bind(this)),
+      actions: prepareHooks(rawData.actions.hooks),
+      filters: prepareHooks(rawData.filters.hooks),
     };
   }
 
-  private transformHook(hook: RawHookData['hooks'][0]): Hook {
-    let hookName = hook.name;
-
+  private escapeHookName(hookName: string): string {
+    let escapedHookName = hookName;
     /**
      * Replace PHP-style interpolations with {$var}_suffix
      * Example:
@@ -77,7 +111,7 @@ export class HookCollector {
      * becomes
      * 'woocommerce_analytics_{$field}_$context'
      */
-    hookName = hookName.replace(
+    escapedHookName = hookName.replace(
       /['"]\s*\.\s*(\$(?:[a-zA-Z_]\w*)(?:->\w+|\[[^\]]+\]|\(\))*((?:->\w+|\[[^\]]+\]|\(\)))*)\s*\.\s*['"]?_?([a-zA-Z0-9_]*)/g,
       (_, variable, rest, suffix) => `{${variable}${rest || ''}}${suffix ? `_${suffix}` : ''}`
     );
@@ -89,7 +123,7 @@ export class HookCollector {
      * becomes
      * 'woocommerce_analytics_{$field}'
      */
-    hookName = hookName.replace(
+    escapedHookName = hookName.replace(
       /['"]\s*\.\s*(\$(?:[a-zA-Z_]\w*)(?:->\w+|\[[^\]]+\]|\(\))*((?:->\w+|\[[^\]]+\]|\(\)))*)/g,
       (_, variable, rest) => `{${variable}${rest || ''}}`
     );
@@ -97,18 +131,28 @@ export class HookCollector {
     /**
      * Remove quotes from hook name
      */
-    hookName = hookName.replace(/['"]/g, '');
+    escapedHookName = hookName.replace(/['"]/g, '');
 
-    const hookId = hookName
+    return escapedHookName;
+  }
+
+  private getHookId(hookName: string): string {
+    return hookName
       .replace(/[^a-zA-Z0-9\-_.~]/g, '')
       .replace(/^__/, '')
       .replace(/^_/, '');
+  }
+
+  private transformHook(hook: RawHookData['hooks'][0]): Hook {
+    const hookName = this.escapeHookName(hook.name);
+    const hookId = this.getHookId(hookName);
 
     return {
       id: hookId,
       name: hookName,
       type: hook.type,
       file: hook.file,
+      files: hook.files || [],
       line: hook.line || 0,
       doc: {
         description: hook.doc?.description || '',

--- a/src/generators/markdown-generator.ts
+++ b/src/generators/markdown-generator.ts
@@ -96,7 +96,7 @@ export class MarkdownGenerator {
       content.push('|------|------|-------------|');
       hook.doc.params.forEach((param) => {
         content.push(
-          `| ${param.name} | \`${param.type}\` | ${this.sanitizeContent(param.description, true)} |`
+          `| ${this.sanitizeContent(param.name)} | \`${this.sanitizeContent(param.type)}\` | ${this.sanitizeContent(param.description, true)} |`
         );
       });
       content.push('');
@@ -216,7 +216,7 @@ export class MarkdownGenerator {
       sanitized = sanitized.replace(/\n/g, '');
     }
 
-    return sanitized.replace(/[{}]/g, (match) => `\\${match}`);
+    return sanitized.replace(/[{}|]/g, (match) => `\\${match}`);
   }
 
   private sanitizeHookName(hookName: string): string {

--- a/src/generators/markdown-generator.ts
+++ b/src/generators/markdown-generator.ts
@@ -114,7 +114,20 @@ export class MarkdownGenerator {
       });
     }
 
-    if (hook.file) {
+    if (hook.files && hook.files.length > 0) {
+      content.push('### Source\n');
+      hook.files.forEach((file) => {
+        if (file.line && file.line > 0 && this.config.githubSourceCodeUrl) {
+          content.push(
+            `- Defined in [\`${file.file}\` at line ${file.line}](${this.config.githubSourceCodeUrl}/${file.file}#L${file.line})`
+          );
+        } else if (file.line && file.line > 0) {
+          content.push(`- Defined in \`${file.file}\` at line ${file.line}`);
+        } else {
+          content.push(`- Defined in \`${file.file}\``);
+        }
+      });
+    } else if (hook.file) {
       content.push('### Source\n');
       if (hook.line && hook.line > 0 && this.config.githubSourceCodeUrl) {
         content.push(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,8 +1,14 @@
+export interface HookFile {
+  file: string;
+  line: number;
+}
+
 export interface Hook {
   id: string;
   name: string;
   type: string;
   file: string;
+  files?: HookFile[];
   line?: number;
   doc: {
     description?: string;
@@ -55,6 +61,7 @@ export interface RawHookData {
     name: string;
     type: string;
     file: string;
+    files?: HookFile[];
     line?: number;
     doc?: {
       description?: string;


### PR DESCRIPTION
### Description of the Change
PR fixes issues with handling multiple parameter types and duplicate hooks. Duplicate hooks were being listed when the same hooks were used multiple times in the codebase with a full docs block. The hook with the comment `This filter is documented in` is already being ignored, so no additional handling is required there.

The PR resolves duplicate hooks by listing each hook only once on the listing page, while providing source links for all hook occurrences on the hook details page.

<img width="868" height="240" alt="image" src="https://github.com/user-attachments/assets/15ee16ee-9f0e-47cc-8b0b-372fc7b442ae" />


Closes #5 

### How to test the Change
1. Check out this PR branch and build it using `npm run build`.
2. Create a sample plugin with a multi-type parameter hook and duplicate hooks (or just use ClassifAI).
3. Install this PR branch as a dependency there and run the doc generation command.
4. Validate the generated docs and ensure that multiple parameter types and duplicate hooks are handled properly.

_(We’ll need a better testing setup going forward, but this is fine for now.)_

### Changelog Entry
> Fixed - Ensure multiple parameter types and duplicate hooks are handled properly.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter, @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
